### PR TITLE
fix: corrige l'import du fichier communes

### DIFF
--- a/lib/rbush-tree.js
+++ b/lib/rbush-tree.js
@@ -1,9 +1,12 @@
+const fs = require('fs')
 const geojsonRbush = require('geojson-rbush').default
 const tree = geojsonRbush()
 
 console.info('Chargement des communes...')
 
-const sourceCommunes = require('../sources/communes-100m.geojson').features
+const sourceCommunes = JSON.parse(
+  fs.readFileSync('./sources/communes-100m.geojson')
+).features
 
 console.info("Insertion dans l'index")
 sourceCommunes.forEach(c => tree.insert(c))


### PR DESCRIPTION
Plus besoin de renommer le fichier `communes-100m.geojson` en `communes-100m.geojson.json`.